### PR TITLE
Adds asp.net core

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@
 - [Golang slack community](https://invite.slack.golangbridge.org/)
 - [The code - active Open Source community](https://community.emccode.com/)
 - [Kotlin lang](http://slack.kotlinlang.org/)
+- [ASP.NET Core](https://aspnetcore.slack.com/). Sign up [here](http://tattoocoder.com/aspnet-slack-sign-up/)


### PR DESCRIPTION
There is a slack team for asp.net core [here](https://aspnetcore.slack.com/) .. added a link to it and a link to where people can sign up to the team.